### PR TITLE
Add repo files for CentOS vault packages

### DIFF
--- a/centos-release-scl/CentOS-6-SCLo-Vault.repo
+++ b/centos-release-scl/CentOS-6-SCLo-Vault.repo
@@ -1,0 +1,83 @@
+# CentOS-6-SCLo-Vault.repo
+#
+# CentOS Vault holds packages from previous releases within the same CentOS Version
+# these are packages obsoleted by the current release and should usually not
+# be used in production
+#-----------------
+
+[C6.0-sclo-SCLGROUP-vault]
+name=CentOS-6.0 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.0/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.1-sclo-SCLGROUP-vault]
+name=CentOS-6.1 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.1/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.2-sclo-SCLGROUP-vault]
+name=CentOS-6.2 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.2/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.3-sclo-SCLGROUP-vault]
+name=CentOS-6.3 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.3/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.4-sclo-SCLGROUP-vault]
+name=CentOS-6.4 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.4/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.5-sclo-SCLGROUP-vault]
+name=CentOS-6.5 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.5/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.6-sclo-SCLGROUP-vault]
+name=CentOS-6.6 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.6/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.7-sclo-SCLGROUP-vault]
+name=CentOS-6.7 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.7/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.8-sclo-SCLGROUP-vault]
+name=CentOS-6.8 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.8/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.9-sclo-SCLGROUP-vault]
+name=CentOS-6.9 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.9/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0
+
+[C6.10-sclo-SCLGROUP-vault]
+name=CentOS-6.10 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/6.10/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
+enabled=0

--- a/centos-release-scl/CentOS-6-SCLo-Vault.repo
+++ b/centos-release-scl/CentOS-6-SCLo-Vault.repo
@@ -5,55 +5,6 @@
 # be used in production
 #-----------------
 
-[C6.0-sclo-SCLGROUP-vault]
-name=CentOS-6.0 -  SCLGROUP Vault
-baseurl=http://vault.centos.org/6.0/sclo/$basearch/SCLGROUP/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-enabled=0
-
-[C6.1-sclo-SCLGROUP-vault]
-name=CentOS-6.1 -  SCLGROUP Vault
-baseurl=http://vault.centos.org/6.1/sclo/$basearch/SCLGROUP/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-enabled=0
-
-[C6.2-sclo-SCLGROUP-vault]
-name=CentOS-6.2 -  SCLGROUP Vault
-baseurl=http://vault.centos.org/6.2/sclo/$basearch/SCLGROUP/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-enabled=0
-
-[C6.3-sclo-SCLGROUP-vault]
-name=CentOS-6.3 -  SCLGROUP Vault
-baseurl=http://vault.centos.org/6.3/sclo/$basearch/SCLGROUP/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-enabled=0
-
-[C6.4-sclo-SCLGROUP-vault]
-name=CentOS-6.4 -  SCLGROUP Vault
-baseurl=http://vault.centos.org/6.4/sclo/$basearch/SCLGROUP/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-enabled=0
-
-[C6.5-sclo-SCLGROUP-vault]
-name=CentOS-6.5 -  SCLGROUP Vault
-baseurl=http://vault.centos.org/6.5/sclo/$basearch/SCLGROUP/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-enabled=0
-
-[C6.6-sclo-SCLGROUP-vault]
-name=CentOS-6.6 -  SCLGROUP Vault
-baseurl=http://vault.centos.org/6.6/sclo/$basearch/SCLGROUP/
-gpgcheck=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
-enabled=0
-
 [C6.7-sclo-SCLGROUP-vault]
 name=CentOS-6.7 -  SCLGROUP Vault
 baseurl=http://vault.centos.org/6.7/sclo/$basearch/SCLGROUP/

--- a/centos-release-scl/CentOS-7-SCLo-Vault.repo
+++ b/centos-release-scl/CentOS-7-SCLo-Vault.repo
@@ -1,0 +1,41 @@
+# CentOS-7-SCLo-Vault.repo
+#
+# CentOS Vault holds packages from previous releases within the same CentOS Version
+# these are packages obsoleted by the current release and should usually not
+# be used in production
+#-----------------
+
+[C7.1-sclo-SCLGROUP-vault]
+name=CentOS-7.1 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/7.1.1503/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0
+
+[C7.2-sclo-SCLGROUP-vault]
+name=CentOS-7.2 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/7.2.1511/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0
+
+[C7.3-sclo-SCLGROUP-vault]
+name=CentOS-7.3 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/7.3.1611/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0
+
+[C7.4-sclo-SCLGROUP-vault]
+name=CentOS-7.4 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/7.4.1708/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0
+
+[C7.5-sclo-SCLGROUP-vault]
+name=CentOS-7.5 -  SCLGROUP Vault
+baseurl=http://vault.centos.org/7.5.1804/sclo/$basearch/SCLGROUP/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=0

--- a/centos-release-scl/centos-release-scl.spec
+++ b/centos-release-scl/centos-release-scl.spec
@@ -1,7 +1,7 @@
 Name:       centos-release-scl
 Epoch:      10
 Version:    6
-Release:    8%{?dist}
+Release:    9%{?dist}
 Summary:    Software collections from the CentOS SCLo SIG
 
 License:    GPLv2
@@ -10,20 +10,44 @@ Source0:    CentOS-SCLo.repo
 Source1:    RPM-GPG-KEY-CentOS-SIG-SCLo
 Source2:    GPL
 
-BuildArch: noarch
+Source6:    CentOS-6-SCLo-Vault.repo
+Source7:    CentOS-7-SCLo-Vault.repo
+
+BuildArch:  noarch
+Requires:   centos-release
 
 %description
 yum Configs and basic docs for Software Collections as delivered via the CentOS SCLo SIG.
 
 %prep
 
+%build
+
 %install
-install -D -m 644 %{SOURCE0} %{buildroot}%{_sysconfdir}/yum.repos.d/CentOS-SCLo-scl.repo
-sed -i -e "s/SCLGROUP/sclo/g" %{buildroot}%{_sysconfdir}/yum.repos.d/CentOS-SCLo-scl.repo
-# variable $releasever in RHEL might expand into something like 7Server, which is not what we want here
-sed -i -e "s/\$releasever/%{?rhel}%{!?rhel:\$releasever}/g" %{buildroot}%{_sysconfdir}/yum.repos.d/CentOS-SCLo-scl.repo
+function install_repo
+{
+    local repo="$1"
+    local repo_renamed="${2:-$repo}"
+
+    install -D -m 644 "$repo" %{buildroot}%{_sysconfdir}/yum.repos.d/"$repo_renamed"
+    # variable $releasever in RHEL might expand into something like 7Server, which is not what we want here
+    sed --in-place \
+        --expression "s/SCLGROUP/sclo/g" \
+        --expression "s/\$releasever/%{?rhel}%{!?rhel:\$releasever}/g" \
+        %{buildroot}%{_sysconfdir}/yum.repos.d/"$repo_renamed"
+}
+
+install_repo %{SOURCE0} CentOS-SCLo-scl.repo
+
 install -p -d %{buildroot}%{_sysconfdir}/pki/rpm-gpg
 install -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/pki/rpm-gpg
+
+%if %{?rhel}%{!?rhel:0} == 6
+install_repo %{SOURCE6} CentOS-SCLo-scl-Vault.repo
+%endif
+%if %{?rhel}%{!?rhel:0} == 7
+install_repo %{SOURCE7} CentOS-SCLo-scl-Vault.repo
+%endif
 
 # use a docdir
 mkdir -p -m 755 %{buildroot}/%{_docdir}/centos-release-scl
@@ -36,6 +60,9 @@ install -m 644 %{SOURCE2} %{buildroot}/%{_docdir}/centos-release-scl
 %{_docdir}/centos-release-scl/*
 
 %changelog
+* Thu Aug 23 2018 Jan Staněk <jstanek@redhat.com> - 10:6-9
+- Add repo definitions for vault
+
 * Mon Jan 18 2016 Honza Horak <hhorak@redhat.com> - 10:6-8
 - Use explicit releasever in repo file
 


### PR DESCRIPTION
This adds repo definitions for SCLo packaged moved to [vault](http://vault.centos.org).

However, I'm unsure about few decisions that was made to prepare this change:

1.  The source package contains definitions for both CentOS 6 and 7 repos.
    The actual file to install is selected during %install.
    Is this OK?

2.  Vault uses general CentOS GPG keys instead of the SCLo ones.
    Currently, the keys should be pulled with newly added dependency on centos-release.
    However, I see from the changelog that this dependency was explicitly dropped before.

    How should the GPG key management be handled?