### PR TITLE
Update CentOS repo url.

### DIFF
--- a/centos-release-scl/CentOS-SCLo.repo
+++ b/centos-release-scl/CentOS-SCLo.repo
@@ -5,15 +5,15 @@
 
 [centos-sclo-SCLGROUP]
 name=CentOS-$releasever - SCLo SCLGROUP
-#baseurl=http://mirror.centos.org/centos/$releasever/sclo/$basearch/SCLGROUP/
-mirrorlist=http://mirrorlist.centos.org?arch=$basearch&release=$releasever&repo=sclo-SCLGROUP
+baseurl=https://vault.centos.org/centos/$releasever/sclo/$basearch/SCLGROUP/
+mirrorlist=https://vault.centos.org?arch=$basearch&release=$releasever&repo=sclo-SCLGROUP
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo
 
 [centos-sclo-SCLGROUP-testing]
 name=CentOS-$releasever - SCLo SCLGROUP Testing
-baseurl=http://buildlogs.centos.org/centos/$releasever/sclo/$basearch/SCLGROUP/
+baseurl=https://buildlogs.centos.org/centos/$releasever/sclo/$basearch/SCLGROUP/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo

--- a/centos-release-scl/CentOS-SCLo.repo
+++ b/centos-release-scl/CentOS-SCLo.repo
@@ -6,7 +6,7 @@
 [centos-sclo-SCLGROUP]
 name=CentOS-$releasever - SCLo SCLGROUP
 baseurl=https://vault.centos.org/centos/$releasever/sclo/$basearch/SCLGROUP/
-mirrorlist=https://vault.centos.org?arch=$basearch&release=$releasever&repo=sclo-SCLGROUP
+# mirrorlist=https://vault.centos.org?arch=$basearch&release=$releasever&repo=sclo-SCLGROUP
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-SCLo


### PR DESCRIPTION
The CentOS repo of `mirror.centos.org` and `mirrorlist.centos.org` have EOL, so I update it via `vault.centos.org` .

> https://vault.centos.org/

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
